### PR TITLE
Fix/DEV-500: Prevent slide navigation when required fields are empty and “Prevent back” is enabled

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -258,19 +258,6 @@ Fliplet.Widget.instance({
 
       let swiper = new Swiper(firstContainer, swiperOptions);
 
-      $sliderElement
-        .find('[data-button-action]')
-        .off('click')
-        .on('click', function() {
-          if ($(this).attr('data-can-swipe') === 'true') {
-            if ($(this).attr('data-button-action') === 'previous-slide') {
-              swiper.slidePrev();
-            } else {
-              swiper.slideNext();
-            }
-          }
-        });
-
 
       swiper.allowSlidePrev = firstSlide.fields.requiredFormBackwardNavigation;
       swiper.allowSlideNext = true;
@@ -322,7 +309,11 @@ Fliplet.Widget.instance({
           const canSwipe = currentSlideForm.every(form => form.$instance.isFormValid);
 
           if (!canSwipe) {
+            const allowSlidePrev = swiper.allowSlidePrev;
+
+            swiper.allowSlidePrev = true;
             swiper.slideTo(swiper.previousIndex, 0, false);
+            swiper.allowSlidePrev = allowSlidePrev;
           }
         }, 0);
       });


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Slider Container

### What does this PR do?

Prevent slide navigation when required fields are empty and “Prevent back” is enabled

### JIRA ticket

[DEV-500](https://weboo.atlassian.net/browse/DEV-500)

[DEV-500]: https://weboo.atlassian.net/browse/DEV-500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ