### PR TITLE
ID-4875 [FEAT] Tracks a user moving from one slide to another.

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -113,15 +113,11 @@ Fliplet.Widget.instance({
       }
 
       function trackEvent(category, action, switchedSlideIndex) {
-        let trackEventOp = Fliplet.App.Analytics.event({
+        Fliplet.App.Analytics.event({
           category,
           action,
           switchedSlideIndex
         });
-
-        if (!(trackEventOp instanceof Promise)) {
-          trackEventOp = Promise.resolve();
-        }
       }
 
       if (interactMode) {
@@ -312,7 +308,11 @@ Fliplet.Widget.instance({
         const forms = await Fliplet.FormBuilder.getAll();
 
         if (!forms.length)  {
-          trackEvent('Slider', 'open', swiper.realIndex);
+          try {
+            trackEvent('Slider', 'open', swiper.realIndex);
+          } catch (error) {
+            console.error('Error tracking event', error);
+          }
 
           return;
         }
@@ -331,7 +331,11 @@ Fliplet.Widget.instance({
             swiper.slideTo(swiper.previousIndex, 0, false);
             swiper.allowSlidePrev = allowSlidePrev;
           } else {
-            trackEvent('Slider', 'open', swiper.realIndex);
+            try {
+              trackEvent('Slider', 'open', swiper.realIndex);
+            } catch (error) {
+              console.error('Error tracking event', error);
+            }
           }
         }, 0);
       });

--- a/js/build.js
+++ b/js/build.js
@@ -112,6 +112,18 @@ Fliplet.Widget.instance({
         }
       }
 
+      function trackEvent(category, action, switchedSlideIndex) {
+        let trackEventOp = Fliplet.App.Analytics.event({
+          category,
+          action,
+          switchedSlideIndex
+        });
+
+        if (!(trackEventOp instanceof Promise)) {
+          trackEventOp = Promise.resolve();
+        }
+      }
+
       if (interactMode) {
         const $screen = $(document, '#preview')
           .contents()
@@ -299,7 +311,11 @@ Fliplet.Widget.instance({
 
         const forms = await Fliplet.FormBuilder.getAll();
 
-        if (!forms.length) return;
+        if (!forms.length)  {
+          trackEvent('Slider', 'open', swiper.realIndex);
+
+          return;
+        }
 
         const previousIndex = swiper.previousIndex;
         const previousSlideId = slides[previousIndex].id;
@@ -314,6 +330,8 @@ Fliplet.Widget.instance({
             swiper.allowSlidePrev = true;
             swiper.slideTo(swiper.previousIndex, 0, false);
             swiper.allowSlidePrev = allowSlidePrev;
+          } else {
+            trackEvent('Slider', 'open', swiper.realIndex);
           }
         }, 0);
       });


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Slider container

### What does this PR do?

Tracks a user moving from one slide to another.

### JIRA ticket

[ID-4875](https://weboo.atlassian.net/browse/ID-4875)

[ID-4875]: https://weboo.atlassian.net/browse/ID-4875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced background analytics for slider open and transition events to improve usage insights.
  * Tracking now fires on successful slide changes, including cases with no forms present.
  * Analytics are handled safely to avoid impacting UI flow or user interactions.
  * No changes to user interface, navigation, form handling, settings or data.
  * No action required from users; background-only improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->