### PR TITLE
Revert "ID-4875 [FEAT] Tracks a user moving from one slide to another."

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -112,14 +112,6 @@ Fliplet.Widget.instance({
         }
       }
 
-      function trackEvent(category, action, switchedSlideIndex) {
-        Fliplet.App.Analytics.event({
-          category,
-          action,
-          switchedSlideIndex
-        });
-      }
-
       if (interactMode) {
         const $screen = $(document, '#preview')
           .contents()
@@ -307,15 +299,7 @@ Fliplet.Widget.instance({
 
         const forms = await Fliplet.FormBuilder.getAll();
 
-        if (!forms.length)  {
-          try {
-            trackEvent('Slider', 'open', swiper.realIndex);
-          } catch (error) {
-            console.error('Error tracking event', error);
-          }
-
-          return;
-        }
+        if (!forms.length) return;
 
         const previousIndex = swiper.previousIndex;
         const previousSlideId = slides[previousIndex].id;
@@ -330,12 +314,6 @@ Fliplet.Widget.instance({
             swiper.allowSlidePrev = true;
             swiper.slideTo(swiper.previousIndex, 0, false);
             swiper.allowSlidePrev = allowSlidePrev;
-          } else {
-            try {
-              trackEvent('Slider', 'open', swiper.realIndex);
-            } catch (error) {
-              console.error('Error tracking event', error);
-            }
           }
         }, 0);
       });


### PR DESCRIPTION
Reverts Fliplet/fliplet-widget-slider-container#20
due to qa failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability when opening sliders by removing a source of errors from background event handling. Slide navigation and form validation behave as before.
- Chores
  - Cleaned up unused background operations in slider transitions to reduce overhead.
  - Streamlined the no-form slide transition path by eliminating redundant steps.
  - No UI changes; users should experience smoother, more stable slider opens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->