### PR TITLE
ID-4875 [FEAT] Tracks a user moving from one slide to another.

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -303,7 +303,15 @@ Fliplet.Widget.instance({
       swiper.on('slideChangeTransitionStart', async function() {
         const activeArrow = this.activeIndex > this.previousIndex ? 'next' : 'prev';
 
-        if (activeArrow === 'prev' || !Fliplet.FormBuilder) return;
+        if (activeArrow === 'prev' || !Fliplet.FormBuilder) {
+          try {
+            trackEvent('Slider', 'open', swiper.realIndex);
+          } catch (error) {
+            console.error('Error tracking event', error);
+          }
+
+          return;
+        }
 
         const forms = await Fliplet.FormBuilder.getAll();
 


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Slider container

### What does this PR do?

Tracks a user moving from one slide to another.

### JIRA ticket

[ID-4875](https://weboo.atlassian.net/browse/ID-4875)


[ID-4875]: https://weboo.atlassian.net/browse/ID-4875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Enhanced analytics coverage for slider navigation, ensuring “open” events are consistently recorded across more scenarios.
  - Added safeguards to prevent tracking from causing errors, improving stability while collecting usage data.
  - Ensures tracking occurs even when no forms are available or when navigating between slides, without changing visible behaviour for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->